### PR TITLE
changed list<point> to list<intersection>

### DIFF
--- a/src/main/geometries/Cylinder.java
+++ b/src/main/geometries/Cylinder.java
@@ -16,7 +16,7 @@ import primitives.Ray;
  * @author Eli Levin
  * @author Abraham Murciano
  */
-public class Cylinder implements Geometry {
+public class Cylinder extends Geometry {
 	private double height;
 
 	private Tube middle;
@@ -73,8 +73,8 @@ public class Cylinder implements Geometry {
 	 * @return a list (possibly empty) of intersection points
 	 */
 	@Override
-	public List<Point> intersect(Ray ray) {
-		List<Point> intersections = new ArrayList<>(2);
+	public List<Intersection> intersect(Ray ray) {
+		List<Intersection> intersections = new ArrayList<>(2);
 		intersections.addAll(intersectLid(ray, bottom));
 		intersections.addAll(intersectLid(ray, top));
 		if (intersections.size() == 2) {
@@ -85,23 +85,23 @@ public class Cylinder implements Geometry {
 	}
 
 	// helper function
-	private List<Point> intersectMiddle(Ray ray) {
-		List<Point> intersections = middle.intersect(ray);
+	private List<Intersection> intersectMiddle(Ray ray) {
+		List<Intersection> intersections = middle.intersect(ray);
 		if (intersections.isEmpty()) {
 			return intersections;
 		}
-		intersections.removeIf(point -> {
-			double intersectionHeight = middle.axis.direction.dot(bottom.point.vectorBaseTo(point));
+		intersections.removeIf(intersection -> {
+			double intersectionHeight = middle.axis.direction.dot(bottom.point.vectorBaseTo(intersection.point));
 			return DoubleCompare.leq(intersectionHeight, 0) || DoubleCompare.geq(intersectionHeight, height);
 		});
 		return intersections;
 	}
 
 	// helper function
-	private List<Point> intersectLid(Ray ray, Plane lid) {
-		List<Point> intersection = lid.intersect(ray);
+	private List<Intersection> intersectLid(Ray ray, Plane lid) {
+		List<Intersection> intersection = lid.intersect(ray);
 		if (!intersection.isEmpty()
-			&& DoubleCompare.leq(intersection.get(0).squareDistance(lid.point), middle.radius * middle.radius)) {
+			&& DoubleCompare.leq(intersection.get(0).point.squareDistance(lid.point), middle.radius * middle.radius)) {
 			return intersection;
 		} else {
 			return Collections.emptyList();

--- a/src/main/geometries/Geometries.java
+++ b/src/main/geometries/Geometries.java
@@ -2,7 +2,6 @@ package geometries;
 
 import java.util.LinkedList;
 import java.util.List;
-import primitives.Point;
 import primitives.Ray;
 
 /**
@@ -46,8 +45,8 @@ public class Geometries implements Intersectible {
 	}
 
 	@Override
-	public List<Point> intersect(Ray ray) {
-		List<Point> result = new LinkedList<>();
+	public List<Intersection> intersect(Ray ray) {
+		List<Intersection> result = new LinkedList<>();
 		for (Intersectible intersectible : intersectibles) {
 			result.addAll(intersectible.intersect(ray));
 		}

--- a/src/main/geometries/Geometry.java
+++ b/src/main/geometries/Geometry.java
@@ -6,7 +6,7 @@ import primitives.NormalizedVector;
 /**
  * Represents a three dimensional shape
  */
-public interface Geometry extends Intersectible {
+public abstract class Geometry implements Intersectible {
 	/**
 	 * Calculates the normal to the {@link Geometry} at the given {@link Point}. If the given {@link Point} is not on
 	 * the surface of the {@link Geometry} the resulting behaviour is undefined.
@@ -14,5 +14,15 @@ public interface Geometry extends Intersectible {
 	 * @param point The {@link Point} at which to calculate the normal.
 	 * @return A {@link NormalizedVector} perpendicular to the surface of the shape at the given {@link Point}.
 	 */
-	public NormalizedVector normal(Point point);
+	public abstract NormalizedVector normal(Point point);
+
+	/**
+	 * Create an intersection object with this geometry and the given {@link Point}.
+	 *
+	 * @param point The point at which the intersection occurs.
+	 * @return An {@link Intersection} with this geometry at the given point.
+	 */
+	protected Intersection intersection(Point point) {
+		return intersection(point);
+	}
 }

--- a/src/main/geometries/Geometry.java
+++ b/src/main/geometries/Geometry.java
@@ -23,6 +23,6 @@ public abstract class Geometry implements Intersectible {
 	 * @return An {@link Intersection} with this geometry at the given point.
 	 */
 	protected Intersection intersection(Point point) {
-		return intersection(point);
+		return new Intersection(this, point);
 	}
 }

--- a/src/main/geometries/Intersectible.java
+++ b/src/main/geometries/Intersectible.java
@@ -1,7 +1,6 @@
 package geometries;
 
 import java.util.List;
-import primitives.Point;
 import primitives.Ray;
 
 /**
@@ -18,6 +17,6 @@ public interface Intersectible {
 	 * @param ray The {@link Ray} to check for intersections.
 	 * @return A list of all the intersections with the given {@link Ray}.
 	 */
-	public List<Point> intersect(Ray ray);
+	public List<Intersection> intersect(Ray ray);
 
 }

--- a/src/main/geometries/Intersection.java
+++ b/src/main/geometries/Intersection.java
@@ -1,5 +1,6 @@
 package geometries;
 
+import primitives.NormalizedVector;
 import primitives.Point;
 
 /**
@@ -23,5 +24,14 @@ public class Intersection {
 	public Intersection(Geometry geometry, Point point) {
 		this.geometry = geometry;
 		this.point = point;
+	}
+
+	/**
+	 * Calculate the normal of the intersected geometry at the intersection point.
+	 *
+	 * @return The normal of the intersection.
+	 */
+	public NormalizedVector normal() {
+		return geometry.normal(point);
 	}
 }

--- a/src/main/geometries/Intersection.java
+++ b/src/main/geometries/Intersection.java
@@ -1,0 +1,27 @@
+package geometries;
+
+import primitives.Point;
+
+/**
+ * This class represents an intersection between a ray and a geometry.
+ *
+ * @author Abraham Murciano
+ * @author Eli Levin
+ */
+public class Intersection {
+	/** The geometry which the ray intersects. */
+	public final Geometry geometry;
+	/** The point at which the intersection occurs. */
+	public final Point point;
+
+	/**
+	 * Construct an intersection at some point with some geometry.
+	 *
+	 * @param geometry The geometry which the ray intersects.
+	 * @param point    The point at which the intersection occurs.
+	 */
+	public Intersection(Geometry geometry, Point point) {
+		this.geometry = geometry;
+		this.point = point;
+	}
+}

--- a/src/main/geometries/Plane.java
+++ b/src/main/geometries/Plane.java
@@ -16,7 +16,7 @@ import primitives.NormalizedVector;
  * @author Abraham Murciano
  * @author Eli Levin
  */
-public class Plane implements Geometry {
+public class Plane extends Geometry {
 	/** A point on the plane. */
 	public final Point point;
 	/** The normal vector of the plane. */
@@ -69,7 +69,7 @@ public class Plane implements Geometry {
 	}
 
 	@Override
-	public List<Point> intersect(Ray ray) {
+	public List<Intersection> intersect(Ray ray) {
 		double ray_dot_normal = ray.direction.dot(normal);
 		if (DoubleCompare.eq(ray_dot_normal, 0)) {
 			return Collections.emptyList(); // ray is parallel to plane
@@ -78,7 +78,7 @@ public class Plane implements Geometry {
 		if (DoubleCompare.leq(distance, 0)) {
 			return Collections.emptyList(); // pane is behind the ray
 		}
-		return List.of(ray.travel(distance));
+		return List.of(intersection(ray.travel(distance)));
 	}
 
 }

--- a/src/main/geometries/Polygon.java
+++ b/src/main/geometries/Polygon.java
@@ -18,7 +18,7 @@ import primitives.NormalizedVector;
  * @author Abraham Murciano
  * @author Eli Levin
  */
-public class Polygon implements Geometry {
+public class Polygon extends Geometry {
 
 	private List<Point> vertices;
 	private Plane plane; // The plane which all the points must reside on.
@@ -84,8 +84,8 @@ public class Polygon implements Geometry {
 	}
 
 	@Override
-	public List<Point> intersect(Ray ray) {
-		List<Point> candidates = plane.intersect(ray);
+	public List<Intersection> intersect(Ray ray) {
+		List<Intersection> candidates = plane.intersect(ray);
 		if (candidates.isEmpty()) { // The ray doesn't intersect the plane
 			return candidates;
 		}

--- a/src/main/geometries/Sphere.java
+++ b/src/main/geometries/Sphere.java
@@ -18,7 +18,7 @@ import math.equations.Quadratic;
  * @author Abraham Murciano
  * @author Eli Levin
  */
-public class Sphere implements Geometry {
+public class Sphere extends Geometry {
 	/** The center of the sphere. */
 	public final Point center;
 	/** The radius of the sphere. */
@@ -53,7 +53,7 @@ public class Sphere implements Geometry {
 	}
 
 	@Override
-	public List<Point> intersect(Ray ray) {
+	public List<Intersection> intersect(Ray ray) {
 		VectorBase centerToRaySource = center.vectorBaseTo(ray.source);
 		double b = 2 * ray.direction.dot(centerToRaySource);
 		double c = centerToRaySource.squareLength() - radius * radius;
@@ -62,10 +62,10 @@ public class Sphere implements Geometry {
 		if (DoubleCompare.leq(discriminant, 0)) {
 			return Collections.emptyList(); // ray is tangent or doesn't intersect at all
 		}
-		List<Point> result = new ArrayList<>(2);
+		List<Intersection> result = new ArrayList<>(2);
 		for (double t : quadratic.solutions()) {
 			if (DoubleCompare.gt(t, 0)) {
-				result.add(ray.travel(t));
+				result.add(intersection(ray.travel(t)));
 			}
 		}
 		return result;

--- a/src/main/geometries/Tube.java
+++ b/src/main/geometries/Tube.java
@@ -22,7 +22,7 @@ import math.matrices.FastMatrixMultSelf;
  * @author Eli Levin
  * @author Abraham Murciano
  */
-public class Tube implements Geometry {
+public class Tube extends Geometry {
 	/** The axis {@link Ray} of the tube. */
 	public final Ray axis;
 	/** The radius of the tube. */
@@ -82,7 +82,7 @@ public class Tube implements Geometry {
 	 * @return a list (possibly empty) of intersection points
 	 */
 	@Override
-	public List<Point> intersect(Ray r) {
+	public List<Intersection> intersect(Ray r) {
 		Point source;
 		if (!axis.source.equals(Point.ORIGIN)) {
 			source = r.source.add(toOrigin);
@@ -121,7 +121,7 @@ public class Tube implements Geometry {
 			}
 			equation = quadratic;
 		}
-		List<Point> intersections = new ArrayList<>(2);
+		List<Intersection> intersections = new ArrayList<>(2);
 		Ray shiftedRay = new Ray(source, r.direction);
 		for (double t : equation.solutions()) {
 			fillList(intersections, shiftedRay, t);
@@ -130,13 +130,13 @@ public class Tube implements Geometry {
 	}
 
 	// helper function for intersection
-	private void fillList(List<Point> intersections, Ray r, double t) {
+	private void fillList(List<Intersection> intersections, Ray r, double t) {
 		if (DoubleCompare.leq(t, 0)) {
 			return;
 		}
 		Point p = r.travel(t);
 		p = p.add(fromOrigin);
-		intersections.add(p);
+		intersections.add(intersection(p));
 	}
 
 }

--- a/src/test/unit/geometries/CylinderTests.java
+++ b/src/test/unit/geometries/CylinderTests.java
@@ -1,9 +1,6 @@
 package unit.geometries;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 import geometries.Cylinder;
@@ -110,35 +107,34 @@ public class CylinderTests {
 		// start in middle and come out side
 		ray = new Ray(new Point(1, 1, 1), new NormalizedVector(-1, 2, 0));
 		Assert.assertEquals("Passes through bottom and comes out top",
-			new HashSet<>(List.of(new Point(0.6796227589829593, 1.6407544820340814, 1.0))),
-			new HashSet<>(cyl.intersect(ray)));
+			Set.of(new Point(0.6796227589829593, 1.6407544820340814, 1.0)), Util.getPoints(cyl.intersect(ray)));
 
 		// pass through bottom and side
-		ray = new Ray(new Point(0, 0, 0), new NormalizedVector(1, 0, 1));
+		ray = new Ray(Point.ORIGIN, new NormalizedVector(1, 0, 1));
 		Assert.assertEquals("Passes through bottom and comes out side",
-			new HashSet<>(List.of(new Point(0.5, 0, 0.5), new Point(2, 0, 2))), new HashSet<>(cyl.intersect(ray)));
+			Set.of(new Point(0.5, 0, 0.5), new Point(2, 0, 2)), Util.getPoints(cyl.intersect(ray)));
 
 		// pass through bottom and top
-		ray = new Ray(new Point(0, 0, 0), new NormalizedVector(3, 2, 2));
+		ray = new Ray(Point.ORIGIN, new NormalizedVector(3, 2, 2));
 		Assert.assertEquals("Passes through bottom and comes out top",
-			new HashSet<>(List.of(new Point(0.4285714285714286, 0.2857142857142857, 0.2857142857142857),
-				new Point(6.857142857142858, 4.571428571428571, 4.571428571428571))),
-			new HashSet<>(cyl.intersect(ray)));
+			Set.of(new Point(0.4285714285714286, 0.2857142857142857, 0.2857142857142857),
+				new Point(6.857142857142858, 4.571428571428571, 4.571428571428571)),
+			Util.getPoints(cyl.intersect(ray)));
 
 		// starts in middle and passes through bottom
 		ray = new Ray(new Point(2, 2, 2), new NormalizedVector(-1, -1, -1));
-		Assert.assertEquals("Starts in middle and passes through bottom",
-			new HashSet<>(List.of(new Point(1d / 3, 1d / 3, 1d / 3))), new HashSet<>(cyl.intersect(ray)));
+		Assert.assertEquals("Starts in middle and passes through bottom", Set.of(new Point(1d / 3, 1d / 3, 1d / 3)),
+			Util.getPoints(cyl.intersect(ray)));
 
 		// starts in middle and passes through top
 		ray = new Ray(new Point(2, 2, 2), new NormalizedVector(1, 1, 1));
 		Assert.assertEquals("Starts in middle and passes through top",
-			new HashSet<>(List.of(new Point(5.333333333333334, 5.333333333333334, 5.333333333333334))),
-			new HashSet<>(cyl.intersect(ray)));
+			Set.of(new Point(5.333333333333334, 5.333333333333334, 5.333333333333334)),
+			Util.getPoints(cyl.intersect(ray)));
 
 		// outside cylinder completely
 		ray = new Ray(new Point(-1, -1, -1), new NormalizedVector(-3, 7, 4));
-		Assert.assertEquals("outside cylinder completely", Collections.emptyList(), cyl.intersect(ray));
+		Assert.assertTrue("outside cylinder completely", cyl.intersect(ray).isEmpty());
 
 		// @formatter:off
 		//  ____                        _
@@ -155,27 +151,26 @@ public class CylinderTests {
 
 		// follows axis
 		ray = new Ray(new Point(0, -1, -1), new NormalizedVector(1, 1, 1));
-		Assert.assertEquals("Follows axis", new HashSet<>(List.of(new Point(1, 0, 0), new Point(6, 5, 5))),
-			new HashSet<>(cyl.intersect(ray)));
+		Assert.assertEquals("Follows axis", Set.of(new Point(1, 0, 0), new Point(6, 5, 5)),
+			Util.getPoints(cyl.intersect(ray)));
 
 		// follows axis and starts on bottom plane
 		ray = new Ray(new Point(1, 0, 0), new NormalizedVector(1, 1, 1));
-		Assert.assertEquals("Follows axis", new HashSet<>(List.of(new Point(6, 5, 5))),
-			new HashSet<>(cyl.intersect(ray)));
+		Assert.assertEquals("Follows axis", Set.of(new Point(6, 5, 5)), Util.getPoints(cyl.intersect(ray)));
 
 		// passes though bottom and CORNER(!) of cylinder
-		ray = new Ray(new Point(0, 0, 0), new NormalizedVector(3, 2, 3));
+		ray = new Ray(Point.ORIGIN, new NormalizedVector(3, 2, 3));
 		Assert.assertEquals("Passes through bottom and comes out corner",
-			new HashSet<>(List.of(new Point(0.375, 0.25, 0.375), new Point(6, 4, 6))),
-			new HashSet<>(cyl.intersect(ray)));
+			Set.of(new Point(0.375, 0.25, 0.375), new Point(6, 4, 6)), Util.getPoints(cyl.intersect(ray)));
 
 		// hits corner from outside near top
 		ray = new Ray(new Point(3, 4, 6), NormalizedVector.I);
-		Assert.assertEquals("Starts outside and hits corner near lid", List.of(new Point(6, 4, 6)), cyl.intersect(ray));
+		Assert.assertEquals("Starts outside and hits corner near lid", Set.of(new Point(6, 4, 6)),
+			Util.getPoints(cyl.intersect(ray)));
 
 		// hits corner from outside near base
 		ray = new Ray(new Point(0, -3, 0), NormalizedVector.J);
-		Assert.assertEquals("Starts outside and hist corner near base", List.of(new Point(0, 1, 0)),
-			cyl.intersect(ray));
+		Assert.assertEquals("Starts outside and hist corner near base", Set.of(new Point(0, 1, 0)),
+			Util.getPoints(cyl.intersect(ray)));
 	}
 }

--- a/src/test/unit/geometries/PlaneTests.java
+++ b/src/test/unit/geometries/PlaneTests.java
@@ -1,6 +1,6 @@
 package unit.geometries;
 
-import java.util.List;
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 import geometries.Plane;
@@ -23,10 +23,12 @@ public class PlaneTests {
 	@Test
 	public void testColinearPoints() {
 		// Non colinear points
-		new Plane(new Point(0, 0, 0), new Point(2, -1, 0), new Point(1, 1, 0));
+		new Plane(Point.ORIGIN, new Point(2, -1, 0), new Point(1, 1, 0));
 		// Colinear points
+		Point p2 = new Point(1, 1, 1);
+		Point p3 = new Point(2, 2, 2);
 		Assert.assertThrows("Colinear points should throw an exception.", IllegalArgumentException.class,
-			() -> new Plane(new Point(0, 0, 0), new Point(1, 1, 1), new Point(2, 2, 2)));
+			() -> new Plane(Point.ORIGIN, p2, p3));
 	}
 
 	/**
@@ -34,7 +36,7 @@ public class PlaneTests {
 	 */
 	@Test
 	public void contains() {
-		Plane plane = new Plane(new Point(0, 0, 0), NormalizedVector.K);
+		Plane plane = new Plane(Point.ORIGIN, NormalizedVector.K);
 
 		// @formatter:off
 		//  _____            _            _
@@ -69,7 +71,7 @@ public class PlaneTests {
 		// @formatter:on
 
 		// Plane's defining point
-		Assert.assertTrue("Plane claims to not contain its defining point.", plane.contains(new Point(0, 0, 0)));
+		Assert.assertTrue("Plane claims to not contain its defining point.", plane.contains(Point.ORIGIN));
 	}
 
 	/**
@@ -77,8 +79,8 @@ public class PlaneTests {
 	 */
 	@Test
 	public void normal() {
-		Plane plane = new Plane(new Point(0, 0, 0), new Point(2, -1, 0), new Point(1, 1, 0));
-		NormalizedVector normal = plane.normal(new Point(0, 0, 0));
+		Plane plane = new Plane(Point.ORIGIN, new Point(2, -1, 0), new Point(1, 1, 0));
+		NormalizedVector normal = plane.normal(Point.ORIGIN);
 		NormalizedVector expected_normal = NormalizedVector.K;
 		Assert.assertTrue("Wrong normal for Polygon.", NormalCompare.eq(normal, expected_normal));
 	}
@@ -88,7 +90,7 @@ public class PlaneTests {
 	 */
 	@Test
 	public void testIntersect() {
-		Plane plane = new Plane(new Point(0, 0, 0), new Point(2, -1, 0), new Point(1, 1, 0));
+		Plane plane = new Plane(Point.ORIGIN, new Point(2, -1, 0), new Point(1, 1, 0));
 		Ray ray;
 
 		// @formatter:off
@@ -107,8 +109,8 @@ public class PlaneTests {
 
 		// Does intersect
 		ray = new Ray(new Point(1, 1, 1), new NormalizedVector(1, 1, -1));
-		Assert.assertEquals("Expected intersection for intersecting ray.", plane.intersect(ray),
-			List.of(new Point(2, 2, 0)));
+		Assert.assertEquals("Expected intersection for intersecting ray.", Set.of(new Point(2, 2, 0)),
+			Util.getPoints(plane.intersect(ray)));
 
 		// Does not intersect (not parallel)
 		ray = new Ray(new Point(1, 1, -1), new NormalizedVector(1, 1, -1));
@@ -140,7 +142,7 @@ public class PlaneTests {
 		Assert.assertTrue("No plane intersection expected for ray starting on plane.", plane.intersect(ray).isEmpty());
 
 		// Ray starts on plane's internal point
-		ray = new Ray(new Point(0, 0, 0), new NormalizedVector(1, 1, 1));
+		ray = new Ray(Point.ORIGIN, new NormalizedVector(1, 1, 1));
 		Assert.assertTrue("No plane intersection expected for ray starting on plane's internal point.",
 			plane.intersect(ray).isEmpty());
 	}

--- a/src/test/unit/geometries/PolygonTests.java
+++ b/src/test/unit/geometries/PolygonTests.java
@@ -1,6 +1,6 @@
 package unit.geometries;
 
-import java.util.List;
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 import geometries.Polygon;
@@ -16,12 +16,26 @@ import primitives.Ray;
  * @author Eli Levin
  */
 public class PolygonTests {
+	private final Point p1 = new Point(1, 1, 1);
+	private final Point p2 = new Point(2, 2, 2);
+	private final Point p3 = new Point(3, 3, 3);
+	private final Point p120 = new Point(1, 2, 0);
+	private final Point p200 = new Point(2, 0, 0);
+	private final Point p110 = new Point(1, 1, 0);
+	private final Point p001 = new Point(0, 0, 1);
+	private final Point p_1 = new Point(-1, -1, -1);
+	private final Point p020 = new Point(0, 2, 0);
+	private final Point p210 = new Point(2, 1, 0);
+	private final Point p101 = new Point(1, 0, 1);
+	private final Point p010 = new Point(0, 1, 0);
+	private final Point p100 = new Point(1, 0, 0);
 
 	/**
 	 * Test Polygon.Polygon
 	 */
 	@Test
 	public void testConstructor() {
+
 		// ===========================================================
 		// Tests that constructor takes at least 3 significant points.
 		// ===========================================================
@@ -41,16 +55,15 @@ public class PolygonTests {
 		// @formatter:on
 
 		// More than three points should not throw an exception.
-		new Polygon(new Point(0, 0, 0), new Point(2, -1, 0), new Point(1, 1, 0), new Point(0.5, 1, 0));
+		new Polygon(Point.ORIGIN, new Point(2, -1, 0), p110, new Point(0.5, 1, 0));
 		// More than three significant points should not throw an exception.
-		new Polygon(new Point(0, 0, 0), new Point(1, -0.5, 0), new Point(2, -1, 0), new Point(1, 1, 0),
-			new Point(0.5, 1, 0));
+		new Polygon(Point.ORIGIN, new Point(1, -0.5, 0), new Point(2, -1, 0), p110, new Point(0.5, 1, 0));
 		// Less than three vertices should throw an exception.
 		Assert.assertThrows("Too few points should throw an exception.", IllegalArgumentException.class,
-			() -> new Polygon(new Point(0, 0, 0), new Point(1, 1, 1)));
+			() -> new Polygon(Point.ORIGIN, p1));
 		// Less than three significant vertices should throw an exception.
 		Assert.assertThrows("Too few significant points should throw an exception.", IllegalArgumentException.class,
-			() -> new Polygon(new Point(0, 0, 0), new Point(1, 1, 1), new Point(2, 2, 2), new Point(3, 3, 3)));
+			() -> new Polygon(Point.ORIGIN, p1, p2, p3));
 
 		// @formatter:off
 		//  ____                        _
@@ -66,9 +79,9 @@ public class PolygonTests {
 		// @formatter:on
 
 		// Exactly three points should not throw an exception.
-		new Polygon(new Point(0, 0, 0), new Point(1, 1, 0), new Point(0.5, 1, 0));
+		new Polygon(Point.ORIGIN, p110, new Point(0.5, 1, 0));
 		// Exactly three significant points should not throw an exception.
-		new Polygon(new Point(0, 0, 0), new Point(1, -0.5, 0), new Point(2, -1, 0), new Point(1, 1, 0));
+		new Polygon(Point.ORIGIN, new Point(1, -0.5, 0), new Point(2, -1, 0), p110);
 
 		// ===================================================
 		// Test that constructor accepts only convex polygons.
@@ -77,23 +90,22 @@ public class PolygonTests {
 		// Equivalence partition tests (there are no boundary values)
 
 		// Convex polygon
-		new Polygon(new Point(0, 0, 1), new Point(2, 2, 2), new Point(1, 1, 0), new Point(-1, -1, -1));
+		new Polygon(p001, p2, p110, p_1);
 
 		// Concave polygons
 		Assert.assertThrows("Concave polygons should throw an exception.", IllegalArgumentException.class,
-			() -> new Polygon(new Point(0, 0, 0), new Point(1, 2, 0), new Point(2, 0, 0), new Point(1, 1, 0)));
+			() -> new Polygon(Point.ORIGIN, p120, p200, p110));
 
 		// Complex polygon - Type 1
 		Assert.assertThrows("Complex polygon should throw an exception.", IllegalArgumentException.class,
-			() -> new Polygon(new Point(0, 0, 0), new Point(1, 2, 0), new Point(2, 0, 0), new Point(0, 2, 0)));
+			() -> new Polygon(Point.ORIGIN, p120, p200, p020));
 		// Complex polygon - Type 2
 		Assert.assertThrows("Complex star polygon should throw an exception.", IllegalArgumentException.class,
-			() -> new Polygon(new Point(0, 0, 0), new Point(1, 2, 0), new Point(2, 0, 0), new Point(0, 2, 0),
-				new Point(2, 1, 0)));
+			() -> new Polygon(Point.ORIGIN, p120, p200, p020, p210));
 
 		// Non-planar polygon
 		Assert.assertThrows("Non-planar polygon should throw an exception.", IllegalArgumentException.class,
-			() -> new Polygon(new Point(0, 0, 0), new Point(1, 2, 0), new Point(0, 2, 0), new Point(1, 0, 1)));
+			() -> new Polygon(Point.ORIGIN, p120, p020, p101));
 
 		// =====================================================
 		// Test that constructor doesn't accept repeated points.
@@ -115,12 +127,10 @@ public class PolygonTests {
 
 		// Repeated points in the middle
 		Assert.assertThrows("Repeated points should throw an exception.", IllegalArgumentException.class,
-			() -> new Polygon(new Point(0, 0, 1), new Point(2, 2, 2), new Point(2, 2, 2), new Point(1, 1, 0),
-				new Point(-1, -1, -1)));
+			() -> new Polygon(p001, p2, p2, p110, p_1));
 		// Repeated end points
 		Assert.assertThrows("Repeated end points should throw an exception.", IllegalArgumentException.class,
-			() -> new Polygon(new Point(0, 0, 0), new Point(0, 1, 0), new Point(1, 1, 0), new Point(1, 0, 0),
-				new Point(0, 0, 0)));
+			() -> new Polygon(Point.ORIGIN, p010, p110, p100, Point.ORIGIN));
 	}
 
 	/**
@@ -128,16 +138,15 @@ public class PolygonTests {
 	 */
 	@Test
 	public void testNormal() {
-		Polygon polygon =
-			new Polygon(new Point(0, 0, 1), new Point(2, 2, 2), new Point(1, 1, 0), new Point(-1, -1, -1));
-		NormalizedVector normal = polygon.normal(new Point(0, 0, 0));
+		Polygon polygon = new Polygon(p001, p2, p110, p_1);
+		NormalizedVector normal = polygon.normal(Point.ORIGIN);
 		NormalizedVector expected_normal = new NormalizedVector(1, -1, 0);
 		Assert.assertTrue("Wrong normal for Polygon.", NormalCompare.eq(normal, expected_normal));
 	}
 
 	@Test
 	public void testIntersect() {
-		Polygon polygon = new Polygon(new Point(0, 0, 0), new Point(1, 0, 0), new Point(1, 1, 1), new Point(0, 1, 1));
+		Polygon polygon = new Polygon(Point.ORIGIN, p100, new Point(1, 1, 1), new Point(0, 1, 1));
 
 		// @formatter:off
 		//  _____            _            _
@@ -155,8 +164,8 @@ public class PolygonTests {
 
 		// Intersection inside polygon
 		Ray ray = new Ray(new Point(0.5, 0, 1), new NormalizedVector(0, 1, -1));
-		Assert.assertEquals("Intersection expected but not found or wrong value.", polygon.intersect(ray),
-			List.of(new Point(0.5, 0.5, 0.5)));
+		Assert.assertEquals("Intersection expected but not found or wrong value.", Set.of(new Point(0.5, 0.5, 0.5)),
+			Util.getPoints(polygon.intersect(ray)));
 
 		// Intersection outside polygon (on outside of only one edge)
 		ray = new Ray(new Point(0.5, 0, 1), new NormalizedVector(2, -1, -1));
@@ -203,7 +212,7 @@ public class PolygonTests {
 		Assert.assertTrue("Expected no intersection from ray starting on boundary.", polygon.intersect(ray).isEmpty());
 
 		// Ray starts on corner
-		ray = new Ray(new Point(0, 0, 0), new NormalizedVector(0.5, 1, 0));
+		ray = new Ray(Point.ORIGIN, new NormalizedVector(0.5, 1, 0));
 		Assert.assertTrue("Expected no intersection from ray starting on corner.", polygon.intersect(ray).isEmpty());
 	}
 }

--- a/src/test/unit/geometries/SphereTests.java
+++ b/src/test/unit/geometries/SphereTests.java
@@ -1,7 +1,6 @@
 package unit.geometries;
 
-import java.util.HashSet;
-import java.util.List;
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 import geometries.Sphere;
@@ -77,13 +76,14 @@ public class SphereTests {
 		ray = new Ray(new Point(-1, 0, 0), new NormalizedVector(3, 1, 0));
 		Point p1 = new Point(0.06515307716504659, 0.35505102572168223, 0);
 		Point p2 = new Point(1.5348469228349528, 0.8449489742783177, 0);
-		Assert.assertEquals("Wrong result for ray crossing sphere.", new HashSet<>(sphere.intersect(ray)),
-			new HashSet<>(List.of(p1, p2)));
+		Assert.assertEquals("Wrong result for ray crossing sphere.", Set.of(p1, p2),
+			Util.getPoints(sphere.intersect(ray)));
 
 		// Ray starts inside the sphere (1 intersection)
 		ray = new Ray(new Point(1.5, 0.5, 0.5), new NormalizedVector(0, -1, -1));
 		p1 = new Point(1.5, -0.612372435695794, -0.612372435695794);
-		Assert.assertEquals("Wrong result for ray starting inside sphere.", sphere.intersect(ray), List.of(p1));
+		Assert.assertEquals("Wrong result for ray starting inside sphere.", Set.of(p1),
+			Util.getPoints(sphere.intersect(ray)));
 
 		// Ray starts after the sphere (no intersections)
 		ray = new Ray(new Point(1.5, -1, -1), new NormalizedVector(0, -1, -1));
@@ -106,7 +106,8 @@ public class SphereTests {
 		// intersection)
 		ray = new Ray(Point.ORIGIN, new NormalizedVector(1, 1, 0));
 		p1 = new Point(1, 1, 0);
-		Assert.assertEquals("Wrong result for ray staring on boundary going in", sphere.intersect(ray), List.of(p1));
+		Assert.assertEquals("Wrong result for ray staring on boundary going in", Set.of(p1),
+			Util.getPoints(sphere.intersect(ray)));
 
 		// Ray starts at surface and goes outside (not directly away from center) (no
 		// intersections)
@@ -118,25 +119,26 @@ public class SphereTests {
 		ray = new Ray(new Point(-1, 0, 0), NormalizedVector.I);
 		p1 = Point.ORIGIN;
 		p2 = new Point(2, 0, 0);
-		Assert.assertEquals("Wrong result for ray going through center of sphere.",
-			new HashSet<>(sphere.intersect(ray)), new HashSet<>(List.of(p1, p2)));
+		Assert.assertEquals("Wrong result for ray going through center of sphere.", Set.of(p1, p2),
+			Util.getPoints(sphere.intersect(ray)));
 
 		// Ray starts at surface and goes inside throuch center (one intersection)
 		ray = new Ray(Point.ORIGIN, NormalizedVector.I);
 		p1 = new Point(2, 0, 0);
-		Assert.assertEquals("Wrong result for ray starting at surface going through center of sphere.",
-			sphere.intersect(ray), List.of(p1));
+		Assert.assertEquals("Wrong result for ray starting at surface going through center of sphere.", Set.of(p1),
+			Util.getPoints(sphere.intersect(ray)));
 
 		// Ray starts inside and passes through center (one intersection)
 		ray = new Ray(new Point(0.5, 0, 0), NormalizedVector.I);
 		p1 = new Point(2, 0, 0);
-		Assert.assertEquals("Wrong result for ray starting inside and going through center of sphere.",
-			sphere.intersect(ray), List.of(p1));
+		Assert.assertEquals("Wrong result for ray starting inside and going through center of sphere.", Set.of(p1),
+			Util.getPoints(sphere.intersect(ray)));
 
 		// Ray starts at the center (one intersection)
 		ray = new Ray(new Point(1, 0, 0), NormalizedVector.I);
 		p1 = new Point(2, 0, 0);
-		Assert.assertEquals("Wrong result for ray starting at center of sphere.", sphere.intersect(ray), List.of(p1));
+		Assert.assertEquals("Wrong result for ray starting at center of sphere.", Set.of(p1),
+			Util.getPoints(sphere.intersect(ray)));
 
 		// Ray starts at sphere and goes outside directly away from center (no
 		// intersections)

--- a/src/test/unit/geometries/TriangleTests.java
+++ b/src/test/unit/geometries/TriangleTests.java
@@ -1,6 +1,6 @@
 package unit.geometries;
 
-import java.util.List;
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 import geometries.Triangle;
@@ -22,15 +22,17 @@ public class TriangleTests {
 	@Test
 	public void testColinearPoints() {
 		// Non colinear points
-		new Triangle(new Point(0, 0, 0), new Point(2, -1, 0), new Point(1, 1, 0));
+		new Triangle(Point.ORIGIN, new Point(2, -1, 0), new Point(1, 1, 0));
 		// Colinear points
+		Point p2 = new Point(1, 1, 1);
+		Point p3 = new Point(2, 2, 2);
 		Assert.assertThrows("Colinear points should throw an exception.", IllegalArgumentException.class,
-			() -> new Triangle(new Point(0, 0, 0), new Point(1, 1, 1), new Point(2, 2, 2)));
+			() -> new Triangle(Point.ORIGIN, p2, p3));
 	}
 
 	@Test
 	public void testIntersect() {
-		Triangle triangle = new Triangle(new Point(0, 0, 0), new Point(1, 0, 0), new Point(1, 1, 1));
+		Triangle triangle = new Triangle(Point.ORIGIN, new Point(1, 0, 0), new Point(1, 1, 1));
 
 		// @formatter:off
 		//  _____            _            _
@@ -48,8 +50,8 @@ public class TriangleTests {
 
 		// Intersection inside triangle
 		Ray ray = new Ray(new Point(0.5, 0, 1), new NormalizedVector(0.5, 1, -1));
-		Assert.assertEquals("Intersection expected but not found or wrong value.", triangle.intersect(ray),
-			List.of(new Point(0.75, 0.5, 0.5)));
+		Assert.assertEquals("Intersection expected but not found or wrong value.", Set.of(new Point(0.75, 0.5, 0.5)),
+			Util.getPoints(triangle.intersect(ray)));
 
 		// Intersection outside triangle (on outside of only one edge)
 		ray = new Ray(new Point(0.5, 0, 1), new NormalizedVector(2, 1, -1));
@@ -96,7 +98,7 @@ public class TriangleTests {
 		Assert.assertTrue("Expected no intersection from ray starting on boundary.", triangle.intersect(ray).isEmpty());
 
 		// Ray starts on corner
-		ray = new Ray(new Point(0, 0, 0), new NormalizedVector(0.5, 1, 0));
+		ray = new Ray(Point.ORIGIN, new NormalizedVector(0.5, 1, 0));
 		Assert.assertTrue("Expected no intersection from ray starting on corner.", triangle.intersect(ray).isEmpty());
 	}
 }

--- a/src/test/unit/geometries/TubeTests.java
+++ b/src/test/unit/geometries/TubeTests.java
@@ -1,9 +1,6 @@
 package unit.geometries;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 import geometries.Tube;
@@ -54,20 +51,20 @@ public class TubeTests {
 
 		// 1. Hits tube twice (starts outside).
 		Ray ray = new Ray(new Point(-1, 5, 2), new NormalizedVector(1, -1, 0));
-		Assert.assertEquals("Ray which passes through center", new HashSet<>(tube.intersect(ray)),
-			new HashSet<>(List.of(p1, p2)));
+		Assert.assertEquals("Ray which passes through center", Set.of(p1, p2), Util.getPoints(tube.intersect(ray)));
 
 		// 2. Hits tube once (starts inside).
 		ray = new Ray(new Point(1, 3, 2), new NormalizedVector(1, -1, 0));
-		Assert.assertEquals("Ray which starts on tube and passes through center", tube.intersect(ray), List.of(p1));
+		Assert.assertEquals("Ray which starts on tube and passes through center", Set.of(p1),
+			Util.getPoints(tube.intersect(ray)));
 
 		// 3. Doesn't intersect tube (starts outside)
 		ray = new Ray(new Point(3, 1, 2), new NormalizedVector(1, -1, 0));
-		Assert.assertEquals("Ray starts outside tube and never enters", tube.intersect(ray), Collections.emptyList());
+		Assert.assertTrue("Ray starts outside tube and never enters", tube.intersect(ray).isEmpty());
 
 		// 4. Doesn't intersect tube (starts inside and is parallel to axis
 		ray = new Ray(new Point(1.5, 2.5, 2), new NormalizedVector(1, 1, 1));
-		Assert.assertEquals("Ray starts inside tube and never exits", tube.intersect(ray), Collections.emptyList());
+		Assert.assertTrue("Ray starts inside tube and never exits", tube.intersect(ray).isEmpty());
 
 		// @formatter:off
 		//  ____                        _
@@ -84,30 +81,31 @@ public class TubeTests {
 
 		// Start on side of cylinder going outwards
 		ray = new Ray(new Point(2, 2, 2), new NormalizedVector(1, -1, 0));
-		Assert.assertEquals("Ray starts on side of tube and points away", tube.intersect(ray), Collections.emptyList());
+		Assert.assertTrue("Ray starts on side of tube and points away", tube.intersect(ray).isEmpty());
 
 		// Start on side of cylinder going inwards
 		ray = new Ray(new Point(2, 2, 2), new NormalizedVector(-1, 1, 0));
-		Assert.assertEquals("Ray starts on side of tube and goes inwards", tube.intersect(ray), List.of(p2));
+		Assert.assertEquals("Ray starts on side of tube and goes inwards", Set.of(p2),
+			Util.getPoints(tube.intersect(ray)));
 
 		// When ray IS axis
 		ray = axis;
-		Assert.assertEquals("Ray is identical to axis", tube.intersect(ray), Collections.emptyList());
+		Assert.assertTrue("Ray is identical to axis", tube.intersect(ray).isEmpty());
 
 		// Tangent to outside of tube
 		ray = new Ray(new Point(3, 3, 1), new NormalizedVector(-1, -1, 1));
-		Assert.assertEquals("Ray is tangent to tube", tube.intersect(ray), Collections.emptyList());
+		Assert.assertTrue("Ray is tangent to tube", tube.intersect(ray).isEmpty());
 
 		// Start on axis and go orthogonal to it
 		ray = new Ray(new Point(0, 2, 1), new NormalizedVector(-1, 1, 0));
-		Assert.assertEquals("Ray starts on axis and is orthogonal to it", tube.intersect(ray),
-			List.of(new Point(-1, 3, 1)));
+		Assert.assertEquals("Ray starts on axis and is orthogonal to it", Set.of(new Point(-1, 3, 1)),
+			Util.getPoints(tube.intersect(ray)));
 
 		// tube's center is at origin
-		tube = new Tube(new Ray(new Point(0, 0, 0), new NormalizedVector(1, 1, 1)), Math.sqrt(2));
+		tube = new Tube(new Ray(Point.ORIGIN, new NormalizedVector(1, 1, 1)), Math.sqrt(2));
 		ray = new Ray(new Point(-1, 3, 1), new NormalizedVector(1, -1, 0));
-		Assert.assertEquals("Ray starts on axis and is orthogonal to it", new HashSet<>(tube.intersect(ray)),
-			new HashSet<>(List.of(new Point(0, 2, 1), new Point(2, 0, 1))));
+		Assert.assertEquals("Ray starts on axis and is orthogonal to it",
+			Set.of(new Point(0, 2, 1), new Point(2, 0, 1)), Util.getPoints(tube.intersect(ray)));
 	}
 
 }

--- a/src/test/unit/geometries/Util.java
+++ b/src/test/unit/geometries/Util.java
@@ -1,0 +1,25 @@
+package unit.geometries;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import geometries.Intersection;
+import primitives.Point;
+
+/**
+ * Helper class for geometry tests.
+ *
+ * @author Abraham Murciano
+ * @author Eli Levin
+ */
+public class Util {
+	/**
+	 * Extracts the intersection points from a list of {@link Intersection}s
+	 *
+	 * @param intersections The list of {@link Intersection}s to extract the points from.
+	 * @return A set of {@link Points} in the intersections.
+	 */
+	public static Set<Point> getPoints(List<Intersection> intersections) {
+		return intersections.stream().map(gp -> gp.point).collect(Collectors.toSet());
+	}
+}


### PR DESCRIPTION
close #38 

I just replaced the function that returns points, coz it's not used anywhere else. the only use case it had was to be used internally by more complex geometries (eg polygon and cylinder) which contained other geometries to aid the calculation of intersections.

For example, a polygon would have a plane, and Polygon::intersect would call its Plane::intersect, then check that those points are also in the polygon, then return those. Now, since Plane::intersect returns a list of Intersection objects, if we simply return those, then the result of Polygon::intersect would be a list of intersections, some of which claim to intersect with the plane contained by the polygon rather than with the polygon itself.

However, I claim that doesn't matter at all, and may in fact make the system more efficient. This is because the purpose of returning `List<Intersection>` is so that we may know, first of all, the emission light, but afterwards, and more importantly, so we can calculate reflections, diffusions, and stuff. All these calculations involve getting the normal of the intersection geometry. However, if the Intersection object which represents an intersection at the base of a cylinder claims to be an intersection with a Cylinder object, then calculating its normal would involve a more expensive computation which involves checking if the point is in either of the two disks or the tube. However, if the Intersection object claims to be an intersection with the contained plane, then calculating the normal with that geometry will be much faster.